### PR TITLE
Rewrote AST in Typed Racket

### DIFF
--- a/proof-of-concept/ast.rkt
+++ b/proof-of-concept/ast.rkt
@@ -15,9 +15,6 @@
 (struct int
   ([n : Integer]))
 
-(struct bool
-  ([b : Boolean]))
-
 (struct string
   ([s : String]))
 
@@ -55,7 +52,7 @@
    [body : (Listof Stmt)]))
 
 (define-type Type
-  (U 'int 'bool 'string 'dynamic 'none arrow star))
+  (U 'int 'string 'dynamic 'none arrow star))
 
 (struct arrow
   ([dom : Type]


### PR DESCRIPTION
Sample:

```matlab
function [outx, outy] = f(x, y)
    outx = y
    outy = x
endfunction

x = f(1, 2)
```

```racket
(list (func 'f
            (list (cons 'x 'int)
                  (cons 'y 'int))
            (list (cons 'outx 'int)
                  (cons 'outy 'int))
            (list (assn (list 'outx) (id 'y))
                    (assn (list 'outy) (id 'x))))
      (decl 'x 'dynamic)
      (decl 'y 'dynamic)
      (assn (list 'x 'y) (app (id 'f) (list (int 1) (int 2)))))
```

For high-order functions:

```racket
(list (func 'apply
            (list (cons 'f (arrow '(int) '(int)))
                  (cons 'x 'int))
            (list (cons 'fx 'int))
            (list (assn '(fx) (app (id 'f) (list (id 'x))))))
      (func 'f
            (list (cons 'x 'int))
            (list (cons 'fx 'int))
            (list (assn '(fx) (int-binop + (id 'x) (int 1)))))
      (decl 'ans 'int)
      (assn '(ans) (app (id 'func) (list (id 'f) (int 1)))))
```